### PR TITLE
nix-profile: allow url-naming legacyPackages attributes

### DIFF
--- a/src/libutil/url-name.cc
+++ b/src/libutil/url-name.cc
@@ -4,7 +4,7 @@
 
 namespace nix {
 
-static const std::string attributeNamePattern("[a-z0-9_-]+");
+static const std::string attributeNamePattern("[a-zA-Z0-9_-]+");
 static const std::regex lastAttributeRegex("(?:" + attributeNamePattern + "\\.)*(?!default)(" + attributeNamePattern +")(\\^.*)?");
 static const std::string pathSegmentPattern("[a-zA-Z0-9_-]+");
 static const std::regex lastPathSegmentRegex(".*/(" + pathSegmentPattern +")");

--- a/tests/unit/libutil/url-name.cc
+++ b/tests/unit/libutil/url-name.cc
@@ -6,6 +6,9 @@ namespace nix {
 /* ----------- tests for url-name.hh --------------------------------------------------*/
 
     TEST(getNameFromURL, getsNameFromURL) {
+        ASSERT_EQ(getNameFromURL(parseURL("flake:nixpkgs#hello")), "hello");
+        ASSERT_EQ(getNameFromURL(parseURL("flake:nixpkgs#packages.x86_64-linux.hello")), "hello");
+
         ASSERT_EQ(getNameFromURL(parseURL("path:/home/user/project")), "project");
         ASSERT_EQ(getNameFromURL(parseURL("path:~/repos/nixpkgs#packages.x86_64-linux.hello")), "hello");
         ASSERT_EQ(getNameFromURL(parseURL("path:.#nonStandardAttr.mylaptop")), "nonStandardAttr.mylaptop");
@@ -63,5 +66,7 @@ namespace nix {
         ASSERT_EQ(getNameFromURL(parseURL("file:.#")), std::nullopt);
         ASSERT_EQ(getNameFromURL(parseURL("path:.#packages.x86_64-linux.default")), std::nullopt);
         ASSERT_EQ(getNameFromURL(parseURL("path:.#packages.x86_64-linux.default^*")), std::nullopt);
+        ASSERT_EQ(getNameFromURL(parseURL("flake:nixpkgs")), std::nullopt);
+        ASSERT_EQ(getNameFromURL(parseURL("flake:nixpkgs#")), std::nullopt);
     }
 }

--- a/tests/unit/libutil/url-name.cc
+++ b/tests/unit/libutil/url-name.cc
@@ -8,11 +8,12 @@ namespace nix {
     TEST(getNameFromURL, getsNameFromURL) {
         ASSERT_EQ(getNameFromURL(parseURL("flake:nixpkgs#hello")), "hello");
         ASSERT_EQ(getNameFromURL(parseURL("flake:nixpkgs#packages.x86_64-linux.hello")), "hello");
+        ASSERT_EQ(getNameFromURL(parseURL("flake:nixpkgs#legacyPackages.x86_64-linux.hello")), "hello");
 
         ASSERT_EQ(getNameFromURL(parseURL("path:/home/user/project")), "project");
         ASSERT_EQ(getNameFromURL(parseURL("path:~/repos/nixpkgs#packages.x86_64-linux.hello")), "hello");
-        ASSERT_EQ(getNameFromURL(parseURL("path:.#nonStandardAttr.mylaptop")), "nonStandardAttr.mylaptop");
-        ASSERT_EQ(getNameFromURL(parseURL("path:./repos/myflake#nonStandardAttr.mylaptop")), "nonStandardAttr.mylaptop");
+        ASSERT_EQ(getNameFromURL(parseURL("path:.#nonStandardAttr.mylaptop")), "mylaptop");
+        ASSERT_EQ(getNameFromURL(parseURL("path:./repos/myflake#nonStandardAttr.mylaptop")), "mylaptop");
         ASSERT_EQ(getNameFromURL(parseURL("path:./nixpkgs#packages.x86_64-linux.complex^bin,man")), "complex");
         ASSERT_EQ(getNameFromURL(parseURL("path:./myproj#packages.x86_64-linux.default^*")), "myproj");
 


### PR DESCRIPTION
This allows uppercase characters to be used in attribute names when url-naming. It avoids issues with `legacyPackages`.

Improves https://github.com/NixOS/nix/pull/9656