### PR TITLE
Allow `narHash` instead of `treeHash` when checking locked Git archive inputs

### DIFF
--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -304,9 +304,9 @@ struct GitArchiveInputScheme : InputScheme
     bool isLocked(const Input & input) const override
     {
         /* Since we can't verify the integrity of the tarball from the
-           Git revision alone, we also require a Git tree hash for
+           Git revision alone, we also require a Git tree hash or NAR hash for
            locking. */
-        return input.getRev().has_value() && getTreeHash(input).has_value();
+        return input.getRev().has_value() && (getTreeHash(input).has_value() || input.getNarHash().has_value());
     }
 
     std::optional<ExperimentalFeature> experimentalFeature() const override


### PR DESCRIPTION
Without this, `nix build` fails because the lockfile doesn't include a `treeHash` for the Git archive inputs (e.g. GitHub), but as I understand it the `narHash` should be equivalent if it exists.